### PR TITLE
Fix update ticket api service

### DIFF
--- a/backend/resell-dapp-api/src/events/event.service.ts
+++ b/backend/resell-dapp-api/src/events/event.service.ts
@@ -86,7 +86,12 @@ export class EventService {
         ticket.onSale = ticketDto.onSale;
         ticket.price = ticketDto.price;
         ticket.date = ticketDto.date;
-        return await event.save();
+        // returns the updated document after finding and updating via mongo object
+        return await this.eventModel.findOneAndUpdate(
+          { _id: event._id },
+          { $set: event },
+          { returnDocument: 'after' },
+        );
       } else {
         throw new HttpException(
           {


### PR DESCRIPTION
Hi guys, the current update ticket endpoint was not working fine because inside the service function, we basically fetch the ticket json object from the ticklist inside the events, we also updated the values of the json object but we dont update the ticketlist back again, that is why the ticket list is never updated. If we push back the updated object to the ticket list it will duplicate it. Was in a hurry so couldnt find any way to replace the object with the new object inside the list so just did a quick fix. Now we do two calls to DB, findOne and findOneAndUpdate. Not the best code but works perfectly fine. and i think we dont have too much time atm. Therefore, Please test, review and merge :)